### PR TITLE
Use proper prop `customStyle` to pass style

### DIFF
--- a/src/components/news-story/index.tsx
+++ b/src/components/news-story/index.tsx
@@ -59,7 +59,7 @@ const NewsStory: React.FC<Props> = (props: Props) => {
             pixelized={pixelizedProfilePicture}
             index={index}
             pixelPerLine={30}
-            css={css`
+            customStyle={css`
               width: 35px;
               height: 35px;
               border-radius: 50%;


### PR DESCRIPTION
Since `news-story` passes custom style with `css`, it does not apply properly; and this causes design break for news page